### PR TITLE
Only include draft and published notes

### DIFF
--- a/scribe/builder.py
+++ b/scribe/builder.py
@@ -163,7 +163,9 @@ class WebsiteBuilder:
         for path in notes_path.rglob("*"):
             if path.suffix == ".md":
                 try:
-                    notes.append(Note.from_file(path))
+                    note = Note.from_file(path)
+                    if note.metadata.status in {NoteStatus.DRAFT, NoteStatus.PUBLISHED}:
+                        notes.append(note)
                 except InvalidMetadataException as e:
                     secho(f"Invalid metadata: {path}: {e}", fg="red")
                     found_error = True

--- a/scribe/note.py
+++ b/scribe/note.py
@@ -182,7 +182,7 @@ class Note:
                 parsed_lines.append(i)
 
         if not metadata_string:
-            # If users haven't specified metadata, assume it is a draft
+            # If users haven't specified metadata, assume it is a scratch note
             return ParsedPayload(NoteMetadata(date=datetime.now().isoformat()), [])
 
         try:

--- a/scribe/tests/test_builder.py
+++ b/scribe/tests/test_builder.py
@@ -4,7 +4,7 @@ from tempfile import TemporaryDirectory
 from pytest import fixture
 
 from scribe.builder import WebsiteBuilder
-from scribe.note import Note
+from scribe.note import Note, NoteStatus
 
 
 @fixture()
@@ -48,3 +48,34 @@ def test_remote_link_www(builder, note_directory):
         local_mapping
     )
     new_text == text
+
+def test_exclude_scratch(builder, note_directory):
+    """
+    Test that excluded notes are not published
+    """
+    with open(note_directory / "scratch_note.md", "w") as file:
+        file.write(
+            """
+            # Scratch Note
+
+            This is a scratch note.
+            """
+        )
+
+    with open(note_directory / "draft_note.md", "w") as file:
+        file.write(
+            """
+            # Draft Note
+
+            meta:
+                date: September 27, 2022
+                status: draft
+
+            This is a draft note.
+            """
+        )
+
+    notes = builder.get_notes(note_directory)
+    assert len(notes) == 1
+
+    assert notes[0].metadata.status == NoteStatus.DRAFT


### PR DESCRIPTION
Starting to use scratch notes more (ie. ones without any metadata in the same folder). Add basic testing coverage and fix a bug with the grep of these notes.