### PR TITLE
Scan markup files for styled html

### DIFF
--- a/scribe/cli/build.py
+++ b/scribe/cli/build.py
@@ -1,3 +1,4 @@
+import subprocess
 from os import environ, unlink
 from pathlib import Path
 from shutil import rmtree
@@ -10,6 +11,7 @@ from click import (
 )
 
 from scribe.builder import WebsiteBuilder
+from scribe.io import get_asset_path
 
 
 def build(notes_path, output_path):
@@ -29,6 +31,12 @@ def build(notes_path, output_path):
 def main(notes: str, output: str, clean: bool, env: str):
     environ["SCRIBE_ENVIRONMENT"] = env
     secho(f"Environment: {env}")
+
+    environ["MARKDOWN_PATH"] = str(Path(notes).expanduser().absolute())
+
+    # Build the styles
+    command = f"cd {get_asset_path('../')} && npm run styles-build"
+    subprocess.run(command, shell=True)
 
     if clean:
         if Path(output).exists():

--- a/scribe/cli/launch.py
+++ b/scribe/cli/launch.py
@@ -1,5 +1,6 @@
 from multiprocessing import Process
-from os import system
+from os import environ, system
+from pathlib import Path
 from time import sleep
 
 from click import (
@@ -59,9 +60,12 @@ def main(notes: str, output: str, port: int, env: str):
     runserver_process = Process(target=runserver, args=[output, port])
     runserver_process.start()
 
+    environ["MARKDOWN_PATH"] = str(Path(notes).expanduser().absolute())
+
     # Launch the styling refresh system
     style_process = Process(
-        target=system, args=[f"cd {get_asset_path('../')} && npm run styles-watch"]
+        target=system,
+        args=[f"cd {get_asset_path('../')} && npm run styles-watch"],
     )
     style_process.start()
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,10 +1,14 @@
+const markdownPath = process.env.MARKDOWN_PATH || null;
+
+const content = [
+  "./scribe/templates/*.{html,js}",
+  ...(markdownPath ? [`${markdownPath}/**/*.md`] : [])
+]
+
+console.log("Building styles based on these files: ", content.join(" | "))
+
 module.exports = {
-  content: [
-    "./scribe/components/*.{html,js}",
-    "./scribe/templates/*.{html,js}",
-    // include markdown docs that might have some custom html markup within them
-    "../public/**/*.md"
-  ],
+  content,
   safelist: [
     "Color-Black",
     "-Color-Red",


### PR DESCRIPTION
Allow notes to include tailwind markup. These will now get picked up during the build process, since we're including the markdown files in the tailwind compilation path.

Also switch to programatically call `styles-build` as part of the build CLI.